### PR TITLE
clear previous output, so model values are displayed for new selected node

### DIFF
--- a/src/main/java/org/dcak/sample/HomePage.java
+++ b/src/main/java/org/dcak/sample/HomePage.java
@@ -1,9 +1,9 @@
 package org.dcak.sample;
 
-import java.awt.image.SampleModel;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -15,12 +15,15 @@ import org.apache.wicket.extensions.markup.html.repeater.tree.content.Folder;
 import org.apache.wicket.extensions.markup.html.tabs.AbstractTab;
 import org.apache.wicket.extensions.markup.html.tabs.ITab;
 import org.apache.wicket.markup.html.WebMarkupContainer;
-import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.visit.IVisit;
+import org.apache.wicket.util.visit.IVisitor;
 import org.dcak.sample.bean.SampleBean;
 import org.dcak.sample.panel.EditSampleBeanPanel;
 
@@ -95,6 +98,8 @@ public class HomePage extends WebPage {
                                         sampleModel.setObject(model.getObject());
                                         art.add(HomePage.this.get("stringModelValue"));
                                         art.add(HomePage.this.get("tabs"));
+                                        
+                                        clearInput();
                                     }
                                 };
                             }
@@ -104,5 +109,13 @@ public class HomePage extends WebPage {
                 }.setOutputMarkupId(true));
 
     }
+	
+	private void clearInput()
+	{
+		visitChildren(Form.class, new IVisitor<Form, Void>() {
+			 public void component(Form form, IVisit<Void> visit) {
+				 form.clearInput();
+			 }
+		});
+	}
 }
-


### PR DESCRIPTION
As I have written on Stackoverflow:
"If you're just swapping the object in your model, all your form components will still hold the previous raw input.

Call Form#clearInput() after you've changed your model object, i.e. after you've chosen a different entity from your tree."
